### PR TITLE
ci: update permissions to be more explicit

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,11 +8,6 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -21,6 +16,10 @@ jobs:
   build:
     name: Compile Source Files
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -54,11 +53,17 @@ jobs:
 
   deploy:
     name: Deploy Dist Files
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    permissions:
+      pages: write
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ jobs:
     name: Test Compilation
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Just saw some other project tweaking their permissions.  I think it's a good think to do, since not all jobs require the same permissions.

I'm not totally sure this is the correct so I added the optional step to detect them.