### PR TITLE
chore: enable html linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,11 @@ import { defineConfig } from "eslint/config";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 import globals from "globals";
 import js from "@eslint/js";
+import html from "@html-eslint/eslint-plugin";
+import {
+  TEMPLATE_ENGINE_SYNTAX,
+  default as htmlParser,
+} from "@html-eslint/parser";
 
 export default defineConfig([
   {
@@ -28,4 +33,24 @@ export default defineConfig([
   js.configs.recommended,
 
   eslintConfigPrettier,
+  {
+    ...html.configs["flat/recommended"],
+    files: ["**/*.html"],
+    plugins: {
+      "@html-eslint": html,
+    },
+    languageOptions: {
+      parser: htmlParser,
+      parserOptions: {
+        templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.HANDLEBAR,
+      },
+    },
+    rules: {
+      ...html.configs["flat/recommended"].rules,
+      "@html-eslint/indent": "off",
+      "@html-eslint/no-extra-spacing-attrs": "off",
+      "@html-eslint/require-closing-tags": "off",
+      "@html-eslint/attrs-newline": "off",
+    },
+  },
 ]);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@babel/core": "7.27.7",
     "@babel/eslint-parser": "7.27.5",
     "@eslint/js": "9.30.1",
+    "@html-eslint/eslint-plugin": "^0.42.0",
+    "@html-eslint/parser": "^0.42.0",
     "@octokit/types": "14.1.0",
     "@types/alpinejs": "3.13.11",
     "@types/eslint": "9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,12 @@ importers:
       '@eslint/js':
         specifier: 9.30.1
         version: 9.30.1
+      '@html-eslint/eslint-plugin':
+        specifier: ^0.42.0
+        version: 0.42.0(eslint@9.30.1(jiti@2.4.2))
+      '@html-eslint/parser':
+        specifier: ^0.42.0
+        version: 0.42.0
       '@octokit/types':
         specifier: 14.1.0
         version: 14.1.0
@@ -359,6 +365,21 @@ packages:
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
+
+  '@html-eslint/eslint-plugin@0.42.0':
+    resolution: {integrity: sha512-TaSt4WLAytFQR+fKW3FM51HhYISxG4xJjsk+8GtHXUu3BSFeJ21X2LAftHPvILxVC0XUbOqn0X+NlfyWdqafKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0
+
+  '@html-eslint/parser@0.42.0':
+    resolution: {integrity: sha512-fLH5u91H4q83jRS+Grlxv229RKd4JQpp4MAwGYdR3CoVtloXBHFC+QvX3+lAlTiDHytTWNNbrCKHfk3vtQWXrg==}
+
+  '@html-eslint/template-parser@0.42.0':
+    resolution: {integrity: sha512-lGKxMategzQ0LgDz09yT5gfLusVYNEd+bWE62gL9jd17fCX1XOHuPWzhCch0GpZ/So8Ayy8cqZiIXr1QBUgrJA==}
+
+  '@html-eslint/template-syntax-parser@0.42.0':
+    resolution: {integrity: sha512-wUgjZJHof/O24e9AwKFip7rSR2+Xr/Oy++GHGOyDJoPQ6bjl9MHdDEbzofT6gDU6wAFx8+YCE4fZl4nnwjNEJQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -848,6 +869,9 @@ packages:
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
+
+  es-html-parser@0.2.0:
+    resolution: {integrity: sha512-snJ7uJC8Dkx/yT0eYZrWcY57rkPU6Zui6YphPynw8r52AWf57gjqMC0GWe7OxSDipwXowFpa3rqckEeAPTOz7w==}
 
   esbuild@0.25.1:
     resolution: {integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==}
@@ -1728,6 +1752,25 @@ snapshots:
 
   '@fortawesome/fontawesome-free@6.7.2': {}
 
+  '@html-eslint/eslint-plugin@0.42.0(eslint@9.30.1(jiti@2.4.2))':
+    dependencies:
+      '@eslint/plugin-kit': 0.3.1
+      '@html-eslint/parser': 0.42.0
+      '@html-eslint/template-parser': 0.42.0
+      '@html-eslint/template-syntax-parser': 0.42.0
+      eslint: 9.30.1(jiti@2.4.2)
+
+  '@html-eslint/parser@0.42.0':
+    dependencies:
+      '@html-eslint/template-syntax-parser': 0.42.0
+      es-html-parser: 0.2.0
+
+  '@html-eslint/template-parser@0.42.0':
+    dependencies:
+      es-html-parser: 0.2.0
+
+  '@html-eslint/template-syntax-parser@0.42.0': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2163,6 +2206,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
+
+  es-html-parser@0.2.0: {}
 
   esbuild@0.25.1:
     optionalDependencies:

--- a/src/community/index.html
+++ b/src/community/index.html
@@ -38,6 +38,7 @@
             >
               <img
                 src="https://img.shields.io/discord/714101903377694741?color=%232C78BF&label=discord&logo=discord"
+                alt="Join our discord server"
               />
             </a>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -53,6 +53,7 @@
               class="flex overflow-x-auto overflow-y-hidden border-bright_black text-center"
             >
               <template x-for="(value, key) in languages">
+                <!-- eslint-disable-next-line @html-eslint/require-li-container -->
                 <li class="flex flex-1">
                   <template x-if="key === activeTab">
                     <a href="#" class="tab tab-active" @click.prevent="">


### PR DESCRIPTION
- Setup html-eslint, htmlhint was removed previously, this replaces it,
  without the handlebars issues (see config).
- Fix some issues reported by linter.

Additionally disable eslint rules that conflict with prettier
formatting. Let prettier handle formatting, eslint handle linting.

Refs:
https://prettier.io/docs/comparison

EDIT: using nvim [ale](https://github.com/dense-analysis/ale), setting handlebars filetype alias to `html` will let ale use the configured linter
```lua
vim.g.ale_linter_aliases = {handlebars = {"html"}}
```