### PR TITLE
chore(renovate): reduce dependency update noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,56 @@
     "customManagers:biomeVersions"
   ],
 
-  "enabledManagers": ["custom.jsonata", "github-actions", "npm"]
+  "enabledManagers": ["custom.jsonata", "github-actions", "npm"],
+
+  "packageRules": [
+    {
+      "description": "Automerge npm dependency pins",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["pin"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge stable non-major npm updates",
+      "matchManagers": ["npm"],
+      "matchCurrentVersion": "!/^0/",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge non-major GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "patch", "minor"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge npm lock file maintenance",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true
+    },
+    {
+      "description": "Group Astro packages",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["astro", "@astrojs/**"],
+      "groupName": "astro"
+    },
+    {
+      "description": "Group Tailwind packages",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/**"],
+      "groupName": "tailwindcss"
+    },
+    {
+      "description": "Group Prettier packages",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["prettier", "prettier-plugin-**"],
+      "groupName": "prettier"
+    },
+    {
+      "description": "Require approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Reduce routine Renovate PR handling while keeping higher-risk dependency updates visible and reviewable.

The rules intentionally build on the existing organization preset rather than duplicating behavior already provided by `config:best-practices`. In particular, the inherited configuration already provides development-dependency pinning, npm minimum release age handling, weekly lock-file maintenance, semantic commits, and Renovate's other best-practice defaults.

## Choices

### Automerge npm pins

Pin updates are eligible for automerge. A pin such as `^7.3.1 -> 7.3.1` tightens the manifest to the version already selected by the lockfile rather than introducing a newer resolved package version. The organization preset already opts into pinning development dependencies, so requiring manual handling of every resulting pin PR adds review noise without meaningfully reducing update risk.

### Automerge stable patch and minor npm updates

Patch and minor npm updates are eligible for automerge when the current version is stable (`>=1.0`). This is intentionally narrower than treating every `devDependency` as low risk: this repository is a statically built Astro application, so packages such as Astro, Tailwind and highlight.js are development dependencies from npm's perspective while still directly affecting the generated production site.

The repository's pull-request CI provides the safety gate before these updates merge: it installs the dependency graph, builds the site, runs `astro:check`, and runs Biome validation.

### Keep 0.x updates manual

The stable-version matcher deliberately excludes dependencies whose current version starts with `0.`. Renovate's documentation warns that pre-1.0 packages can introduce breaking changes in minor or patch releases, so those updates remain reviewable instead of being treated like stable SemVer patch/minor releases.

Pins are separate from this rule because pinning an existing range does not upgrade the resolved dependency.

### Automerge non-major GitHub Actions updates

Digest, patch, and minor GitHub Actions updates are eligible for automerge. The inherited preset already pins action references to immutable digests while retaining SemVer comments. Routine digest/non-major movement can therefore rely on CI while major action changes remain explicitly reviewed.

### Automerge weekly lock-file maintenance

The organization preset already schedules lock-file maintenance weekly. This rule does not duplicate that schedule; it only allows successful maintenance PRs to merge automatically after validation.

### Group only coupled ecosystems

Grouping is deliberately limited to packages that are expected to move together:

- Astro: `astro` and `@astrojs/**`
- Tailwind: `tailwindcss` and `@tailwindcss/**`
- Prettier: `prettier` and `prettier-plugin-*`

Unrelated site dependencies such as Font Awesome, simple-icons, highlight.js and the Srcery palette are intentionally not collected into a generic dependency group. Broad groups reduce PR count but make failures harder to attribute and make it harder to defer or ignore one problematic update without also blocking unrelated updates.

These grouping rules can combine with the automerge rules because Renovate merges all matching `packageRules`; grouping describes how related updates are collected, while the earlier rules determine whether the resulting update is eligible for automerge.

### Gate major updates through the Dependency Dashboard

Major updates are not disabled. Instead, `dependencyDashboardApproval` prevents Renovate from opening their PRs until explicitly approved from the Dependency Dashboard. This keeps major upgrades discoverable without creating unsolicited high-impact PRs.

The major rule also naturally prevents the stable patch/minor automerge rule from applying because it matches a different update type.

## Expected result

Routine pins, stable patch/minor updates, GitHub Action maintenance, and weekly lock-file maintenance should require little or no manual PR handling when CI succeeds. Pre-1.0 upgrades and major releases retain an explicit human decision point, while closely related ecosystems are updated together rather than producing independent PRs for packages that are normally upgraded as a unit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved dependency update management with automated handling for compatible package and workflow updates.
  - Related updates are now grouped for easier review, while major updates require additional approval.
  - Lockfile maintenance is handled automatically to help keep dependencies current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->